### PR TITLE
Probes, resources & upgrade strategy

### DIFF
--- a/apps/static/base/deployment.yaml
+++ b/apps/static/base/deployment.yaml
@@ -3,6 +3,13 @@ kind: Deployment
 metadata:
   name: dpl
 spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 33%
   template:
     spec:
       containers:
@@ -11,3 +18,22 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
+            limits:
+              memory: 256Mi
+              cpu: 1
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5

--- a/apps/static/overlays/prod/kustomization.yaml
+++ b/apps/static/overlays/prod/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: static
+    newName: ghcr.io/developer-overheid-nl/don-static
+    newTag: 08df8630e31bf46a2dafb8da89f8c8e113835606
+
+patches:
+  - target:
+      kind: Ingress
+      name: don-static-ing
+    patch: |
+      - op: replace
+        path: /spec/rules/0/host
+        value: static.developer.overheid.nl
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: static.developer.overheid.nl
+  - target:
+      kind: Deployment
+      name: don-static-dpl
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 2


### PR DESCRIPTION
- Set number of replicas
- Limit number of retained replicasets
- Optimize rolling upgrade strategy
- Set resource limits (cpu & mem)
- Enable probes (health checks)
