### PR TITLE
feat: migrate Route parentRefs from XListenerSet to ListenerSet

### DIFF
--- a/apps/api/overlays/prod/apisix-http-route.yaml
+++ b/apps/api/overlays/prod/apisix-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: apisix-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-api
@@ -23,8 +23,8 @@ metadata:
   name: apisix-admin-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-api-admin

--- a/apps/api/overlays/prod/don-schema-register-http-route.yaml
+++ b/apps/api/overlays/prod/don-schema-register-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: don-schema-register-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-schemas

--- a/apps/api/overlays/prod/register-site-http-route.yaml
+++ b/apps/api/overlays/prod/register-site-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: register-site-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-apis

--- a/apps/api/overlays/test/apisix-http-route.yaml
+++ b/apps/api/overlays/test/apisix-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: apisix-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test
@@ -23,8 +23,8 @@ metadata:
   name: apisix-admin-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/api/overlays/test/don-schema-register-http-route.yaml
+++ b/apps/api/overlays/test/don-schema-register-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: don-schema-register-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/api/overlays/test/register-site-http-route.yaml
+++ b/apps/api/overlays/test/register-site-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: register-site-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/auth/overlays/prod/http-route.yaml
+++ b/apps/auth/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-auth

--- a/apps/auth/overlays/test/http-route.yaml
+++ b/apps/auth/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/frontend/overlays/prod/http-route.yaml
+++ b/apps/frontend/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-frontend

--- a/apps/frontend/overlays/test/http-route.yaml
+++ b/apps/frontend/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/oss/overlays/prod/http-route.yaml
+++ b/apps/oss/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-oss

--- a/apps/oss/overlays/test/http-route.yaml
+++ b/apps/oss/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/search/overlays/prod/http-route.yaml
+++ b/apps/search/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-search

--- a/apps/search/overlays/test/http-route.yaml
+++ b/apps/search/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/static/overlays/prod/http-route.yaml
+++ b/apps/static/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-static

--- a/apps/static/overlays/test/http-route.yaml
+++ b/apps/static/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test


### PR DESCRIPTION
Point HTTPRoute parentRefs at the standard ListenerSet (`gateway.networking.k8s.io/v1`) instead of experimental XListenerSet (`gateway.networking.x-k8s.io/v1alpha1`), which is removed in Gateway API v1.6.

Requires the standard ListenerSet on the gateway and Istio >= 1.30 to reconcile it. **Do not merge before that cutover** — on Istio 1.29 these routes would detach from their listener and stop serving. Kept as Draft until the platform coordinates the switch.

Affects all prod + test overlays under `apps/*/overlays/` (16 HTTPRoutes).