### PR TITLE
chore(auth): disable redundant nginx Ingress for prod keycloak

### DIFF
--- a/apps/api/overlays/prod/apisix-http-route.yaml
+++ b/apps/api/overlays/prod/apisix-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: apisix-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-api
@@ -23,8 +23,8 @@ metadata:
   name: apisix-admin-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-api-admin

--- a/apps/api/overlays/prod/don-schema-register-http-route.yaml
+++ b/apps/api/overlays/prod/don-schema-register-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: don-schema-register-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-schemas

--- a/apps/api/overlays/prod/register-site-http-route.yaml
+++ b/apps/api/overlays/prod/register-site-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: register-site-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-apis

--- a/apps/api/overlays/test/apisix-http-route.yaml
+++ b/apps/api/overlays/test/apisix-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: apisix-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test
@@ -23,8 +23,8 @@ metadata:
   name: apisix-admin-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/api/overlays/test/don-schema-register-http-route.yaml
+++ b/apps/api/overlays/test/don-schema-register-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: don-schema-register-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/api/overlays/test/register-site-http-route.yaml
+++ b/apps/api/overlays/test/register-site-http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: register-site-http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/auth/overlays/prod/http-route.yaml
+++ b/apps/auth/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-auth

--- a/apps/auth/overlays/prod/kustomization.yaml
+++ b/apps/auth/overlays/prod/kustomization.yaml
@@ -28,11 +28,8 @@ patches:
         path: /spec/values/externalDatabase/host
         value: don-db-postgres-rw.tn-don-db-prod
       - op: replace
-        path: /spec/values/ingress/hostname
-        value: auth.developer.overheid.nl
-      - op: replace
-        path: /spec/values/ingress/extraTls/0/hosts/0
-        value: auth.developer.overheid.nl
+        path: /spec/values/ingress/enabled
+        value: false
       - op: replace
         path: /spec/values/proxyHeaders
         value: xforwarded

--- a/apps/auth/overlays/test/http-route.yaml
+++ b/apps/auth/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/frontend/overlays/prod/http-route.yaml
+++ b/apps/frontend/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-frontend

--- a/apps/frontend/overlays/test/http-route.yaml
+++ b/apps/frontend/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/oss/overlays/prod/http-route.yaml
+++ b/apps/oss/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-oss

--- a/apps/oss/overlays/test/http-route.yaml
+++ b/apps/oss/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/search/overlays/prod/http-route.yaml
+++ b/apps/search/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-search

--- a/apps/search/overlays/test/http-route.yaml
+++ b/apps/search/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test

--- a/apps/static/overlays/prod/http-route.yaml
+++ b/apps/static/overlays/prod/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-prod-static

--- a/apps/static/overlays/test/http-route.yaml
+++ b/apps/static/overlays/test/http-route.yaml
@@ -4,8 +4,8 @@ metadata:
   name: http-route
 spec:
   parentRefs:
-    - group: gateway.networking.x-k8s.io
-      kind: XListenerSet
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
       name: tn-don
       namespace: istio-gateway
       sectionName: tn-don-test


### PR DESCRIPTION
Stacked on #214 (XListenerSet → ListenerSet migration) — **merge #214 first**.

`auth.developer.overheid.nl` is served by the public-gateway HTTPRoute, with DNS already cut over to the gateway (`.209`). The keycloak chart's nginx Ingress is redundant, so disable it for prod (`ingress.enabled: false`).

Equivalence verified live: same `don-auth-keycloak:80` backend; the HTTPRoute serves 302 via the gateway today.

### Note on the diff
This branch is based on #214's `chore/migrate-routes-to-listenerset`, so until #214 merges this PR's diff also shows the XListenerSet→ListenerSet commit. Once #214 lands, only the `ingress.enabled: false` change remains. It's ordered this way because the `tn-don-auth` Kustomization currently fails to reconcile — the cluster VAP rejects the XListenerSet route — so removing the Ingress can't apply until #214's parentRef fix is in.