### PR TITLE
feat(db): CNPG barman-cloud backups for don-db-prod

### DIFF
--- a/apps/db/overlays/prod/cnpg-object-store.yaml
+++ b/apps/db/overlays/prod/cnpg-object-store.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: garage
+spec:
+  # Garage rejects the AWS SDK's newer default checksums and only speaks
+  # path-style addressing; pin both off/on for the in-pod barman sidecar.
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
+      - name: AWS_S3_ADDRESSING_STYLE
+        value: path
+      # Garage's S3 region is "garage"; without this boto defaults to
+      # us-east-1 and Garage 400s the HeadBucket preflight that
+      # barman-cloud-check-wal-archive runs on the first WAL, so continuous
+      # archiving never starts for a freshly bootstrapped cluster.
+      - name: AWS_DEFAULT_REGION
+        value: garage
+  configuration:
+    destinationPath: s3://cnpg-barman-digikluster/
+    endpointURL: https://garage.digikluster.digilab.network
+    s3Credentials:
+      accessKeyId:
+        # namePrefix "don-db-" is applied to the Secret; kustomize does not
+        # rewrite this CRD field, so reference the built name explicitly.
+        name: don-db-s3-db-backups-creds
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: don-db-s3-db-backups-creds
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+    data:
+      compression: gzip
+  retentionPolicy: "30d"

--- a/apps/db/overlays/prod/cnpg-scheduled-backup.yaml
+++ b/apps/db/overlays/prod/cnpg-scheduled-backup.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres
+spec:
+  # Nightly at 04:00, staggered to avoid the digilab-ops tenant slots
+  # (01:00-02:30) and codeplatform's 03:00 slot.
+  schedule: "0 0 4 * * *"
+  immediate: false # the immediate backup fires before the pod finishes restarting with the sidecar
+  backupOwnerReference: self
+  # prod runs 2 instances: back up from a standby to spare the primary.
+  target: prefer-standby
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    # namePrefix "don-db-" is applied to the Cluster; reference built name.
+    name: don-db-postgres

--- a/apps/db/overlays/prod/kustomization.yaml
+++ b/apps/db/overlays/prod/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 resources:
   - ../../base
+  - cnpg-object-store.yaml
+  - cnpg-scheduled-backup.yaml
+  - secret-s3-db-backups-creds.yaml
 
 namespace: tn-don-db-prod
 namePrefix: don-db-
@@ -15,3 +18,20 @@ patches:
       - op: replace
         path: /spec/instances
         value: 2
+      # NOTE: do NOT set primaryUpdateMethod: switchover together with this
+      # initial plugin add. On a running cluster the soon-to-be-demoted primary
+      # has no barman sidecar yet, so it cannot archive WAL and the switchover
+      # deadlocks. The default (restart) instead restarts the primary in place
+      # to gain the sidecar (one brief ~30s blip). Switch to switchover in a
+      # follow-up once the plugin is live, for clean future updates.
+      - op: add
+        path: /spec/plugins
+        value:
+          - name: barman-cloud.cloudnative-pg.io
+            isWALArchiver: true
+            parameters:
+              # ObjectStore/Secret get the "don-db-" namePrefix; reference the
+              # built name (kustomize does not rewrite CRD-internal refs).
+              barmanObjectName: don-db-garage
+              # Namespace the shared bucket per tenant/cluster so backups can't collide.
+              serverName: tn-don-db-prod/don-db-postgres

--- a/apps/db/overlays/prod/secret-s3-db-backups-creds.yaml
+++ b/apps/db/overlays/prod/secret-s3-db-backups-creds.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: s3-db-backups-creds
+type: Opaque
+stringData:
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:fuCKd6SzO6oByHJdMtzWNeoigY/OCmkvN1E=,iv:/8drv/tJFtzUjz/x/kT0IJc87QuXofmW0QEESN6DHTY=,tag:QikfF7S/yF+S74hq8QUPfg==,type:str]
+    ACCESS_SECRET_KEY: ENC[AES256_GCM,data:XkbZJnL3o1wLw4Vr3dk1mS4q40kjtoMoNcnuwKUZki6XR4nHaGke+imPIWnjEt6k/JnmqNAXbOfgl71f0h01qQ==,iv:3Xabuq6HFH8uzwt7AEMxMSfr3aws7lVJKFPg20T48AM=,tag:N/On62ZAjs6/jMiku46RJw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEcXR6UGcxVnJpYWN2aW1X
+            L0NoV0VQOXB0cDdzNjRMaVZRVmg2TDZHNlZVCmpYQmlDMncvMlJPMG9YdmxLVVlk
+            UGpaVGFrcU4yNFExNUZyU2hzYkcyZXMKLS0tIExJaTFMelY1L0NhMEt3Vy9OL0RX
+            bFVwd3VRS3VPaENzSDJwbkRzNjdJbmMKKkTSieyzattySU3qSMmwCkvlqAJaI3zi
+            1lVv3/qSqGtkK02i3zftql2Kfz7r4ostE0ozbZSqfqzrkT753cfa/w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1jpw5maslwqs6av7qxj62qc8gz2g496ul0v0kfz3lzsucfqr45e8qkyx8fd
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-23T07:36:17Z"
+    mac: ENC[AES256_GCM,data:INz5J1QKf4eukc2xB0z4TaXDqjZHdJGvcqErUaVBSrnmUyrRRdBb8IkV2lHNQO94awnKceGpxsP68UPSf8TrYdb7cLdHEL/06uEdqFuh/VDR4cDFkRES3AoYp7cd0kgRxqdFfzNtnCVlAQaKUvobBiQUPReEah9OQRXBCCXLvuE=,iv:j0u1lMoEYBHE7pImlcG6k16oU5jgQHXFUNRX0bQq1TY=,tag:RefyjSlwO3m00rNNpVVLzQ==,type:str]
+    version: 3.13.0


### PR DESCRIPTION
Enable proper CNPG backups for the production don Postgres cluster (`tn-don-db-prod/don-db-postgres`), mirroring the code.overheid.nl setup. Backups are added in the **prod overlay only** — the shared base and the test overlay are untouched (verified: test build has zero backup refs).