### PR TITLE
fix(apisix): bump to 3.17.0-ubuntu for critical CVE auth-bypass fixes

### DIFF
--- a/apps/api/base/apisix/apisix.yaml
+++ b/apps/api/base/apisix/apisix.yaml
@@ -26,7 +26,7 @@ spec:
   values:
     image:
       repository: apache/apisix
-      tag: 3.15.0-ubuntu
+      tag: 3.17.0-ubuntu
     ingress-controller:
       enabled: false
       config:


### PR DESCRIPTION
Bumps Apache APISIX from `3.15.0-ubuntu` to `3.17.0-ubuntu`.

Patches three critical (CVSS 9.1) authentication-bypass vulnerabilities:
- CVE-2026-39999
- CVE-2026-49230
- CVE-2026-31908

Scope: single change in `apps/api/base/apisix/apisix.yaml` (image tag only); applies to both prod (`tn-don-api-prod`) and test (`tn-don-api-test`) via the shared base. Kustomize builds validated for both overlays.