### PR TITLE
fix(typesense): bump to 29.1 for CVE-2026-47216 unauthenticated DoS

### DIFF
--- a/apps/search/overlays/prod/kustomization.yaml
+++ b/apps/search/overlays/prod/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 images:
   - name: typesense
     newName: typesense/typesense
-    newTag: "28.0"
+    newTag: "29.1"
   - name: docsearch-scraper
     newName: typesense/docsearch-scraper
     newTag: "0.11.0"

--- a/apps/search/overlays/test/kustomization.yaml
+++ b/apps/search/overlays/test/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 images:
   - name: typesense
     newName: typesense/typesense
-    newTag: "29.0"
+    newTag: "29.1"
   - name: docsearch-scraper
     newName: typesense/docsearch-scraper
     newTag: "0.11.0"


### PR DESCRIPTION
Bumps Typesense to `29.1`, patching **CVE-2026-47216** — an unauthenticated denial-of-service via the `/multi_search` endpoint affecting Typesense `<= 29.0`.

Changes (image tag pinned per overlay via the Kustomize `images` transformer):
- `apps/search/overlays/prod/kustomization.yaml` (tn-don-search-prod): `28.0` → `29.1`
- `apps/search/overlays/test/kustomization.yaml` (tn-don-search-test): `29.0` → `29.1`

Only the `typesense/typesense` tag is changed; the `docsearch-scraper` image is untouched. Kustomize builds validated for both overlays (rendered image is `typesense/typesense:29.1`).