### PR TITLE
fix(api): add don-register-schema-site image mapping to prod overlay

### DIFF
--- a/apps/api/overlays/prod/kustomization.yaml
+++ b/apps/api/overlays/prod/kustomization.yaml
@@ -22,6 +22,9 @@ images:
   - name: don-register-site
     newName: ghcr.io/developer-overheid-nl/don-register-site
     newTag: 79f06d7c30d2c28c6db18fda8d5bdbf223278372
+  - name: don-register-schema-site
+    newName: ghcr.io/developer-overheid-nl/don-register-schema-site
+    newTag: f1433831cd7a107e881565db90d8d0477833e473
   - name: don-tools-api
     newName: ghcr.io/developer-overheid-nl/don-api-tools
     newTag: dea9f870f88ac8f5eef77b71af605e520d017a83


### PR DESCRIPTION
The prod `api` overlay is missing an `images:` entry for the `don-register-schema-site` container. The base declares `image: don-register-schema-site` (bare name), so without the mapping it resolves to `docker.io/library/don-register-schema-site:latest` — which doesn't exist — and the pod sits in `ImagePullBackOff` (currently ~44h in `tn-don-api-prod` on digikluster).

This mirrors the test overlay, which already has the entry and runs fine. Tag `f1433831…` is the only published `don-register-schema-site` image (prod's older `don-register-site` release `79f06d7c` predates this component and has no matching schema-site image), and it's the version already validated in test.

Fixes the prod `schema-register-site` ImagePullBackOff. Note: the separate `schema-register` CreateContainerConfigError (missing `schema-secrets`) in prod is not addressed here.