### PR TITLE
fix(static): restore source-meta image transform in prod overlay

### DIFF
--- a/apps/static/overlays/prod/kustomization.yaml
+++ b/apps/static/overlays/prod/kustomization.yaml
@@ -12,9 +12,9 @@ images:
   - name: static
     newName: ghcr.io/developer-overheid-nl/don-static
     newTag: b9342c5bc0e61f04742df858ae8eb6d990526485
-  # - name: source-meta
-  #   newName: ghcr.io/developer-overheid-nl/source-meta-schemas
-  #   newTag: 4edd28afc60286b3c4cbd9ff76effc6f8ca1a628
+  - name: source-meta
+    newName: ghcr.io/developer-overheid-nl/source-meta-schemas
+    newTag: 4edd28afc60286b3c4cbd9ff76effc6f8ca1a628
 
 patches:
   - target:


### PR DESCRIPTION
Restores the commented-out `source-meta` image transform so the prod overlay stops rendering the bare placeholder image name `source-meta` (which is unpullable and leaves the pod in ImagePullBackOff); pinned to `4edd28af`, the tag currently running in tn-don-static-prod, so this is a no-op for the running workload. Closes #314